### PR TITLE
Added an OracleProvider and a bunch of options to the query query_for…

### DIFF
--- a/lib/Footprintless/Plugin/Database/OracleProvider.pm
+++ b/lib/Footprintless/Plugin/Database/OracleProvider.pm
@@ -1,0 +1,116 @@
+use strict;
+use warnings;
+
+package Footprintless::Plugin::Database::OracleProvider;
+
+# ABSTRACT: A Oracle provider implementation
+# PODNAME: Footprintless::Plugin::Database::OracleProvider
+
+use parent qw(Footprintless::Plugin::Database::AbstractProvider);
+
+use overload q{""} => 'to_string', fallback => 1;
+
+use Carp;
+use File::Temp;
+use Footprintless::Command qw(
+  command
+  pipe_command
+  sed_command
+);
+use Footprintless::Mixins qw(
+  _run_or_die
+);
+use Log::Any;
+
+my $logger = Log::Any->get_logger();
+
+
+sub _client_command {
+    my ( $self, $command, @additional_options ) = @_;
+
+    my $cnf = $self->_cnf();
+    my ( $hostname, $port ) = $self->_hostname_port();
+
+    return join( ' ', $command, @additional_options );
+}
+
+sub client {
+    my ( $self, %options ) = @_;
+
+    my $in_file;
+    eval {
+        my $in_handle = delete( $options{in_handle} );
+        if ( $options{in_file} ) {
+            open( $in_file, '<', delete( $options{in_file} ) )
+              || croak("invalid in_file: $!");
+        }
+        if ( $options{in_string} ) {
+            my $string = delete( $options{in_string} );
+            open( $in_file, '<', \$string )
+              || croak("invalid in_string: $!");
+        }
+        $self->_connect_tunnel();
+
+        my $command = $self->_client_command(
+            'sqlplus', @{ $options{client_options} },
+            '/nolog', sprintf( "'\@%s'", $self->_cnf() )
+        );
+        $self->_run_or_die(
+            $command,
+            {
+                in_handle => $in_file || $in_handle || \*STDIN,
+                out_handle => \*STDOUT,
+                err_handle => \*STDERR
+            }
+        );
+    };
+    my $error = $@;
+    $self->disconnect();
+    if ($in_file) {
+        close($in_file);
+    }
+
+    croak($error) if ($error);
+}
+
+sub _cnf {
+    my ($self) = @_;
+
+    if ( !$self->{cnf} ) {
+        my ( $hostname, $port ) = $self->_hostname_port();
+        File::Temp->safe_level(File::Temp::HIGH);
+        my $cnf = File::Temp->new( SUFFIX => '.sql' );
+        if ( !chmod( 0600, $cnf ) ) {
+            croak("unable to create secure temp file");
+        }
+        printf( $cnf "connect %s/%s\@%s:%d/%s\n",
+            $self->{username}, $self->{password}, $hostname, $port,
+            $self->{schema} );
+        close($cnf);
+        $self->{cnf} = $cnf;
+        if ( lc($^O) eq 'cygwin' ) {
+            $self->{cnf_ms_windows} = `cygpath --windows $cnf`;
+            chomp( $self->{cnf_ms_windows} );
+        }
+    }
+
+    return $self->{cnf_ms_windows} || $self->{cnf};
+}
+
+sub _connection_string {
+    my ($self) = @_;
+    my ( $hostname, $port ) = $self->_hostname_port();
+    return
+      sprintf( "dbi:Oracle://%s:%d/%s", $hostname, $port, $self->{schema} );
+}
+
+sub _init {
+    my ( $self, %options ) = @_;
+    $self->Footprintless::Plugin::Database::AbstractProvider::_init(%options);
+
+    $self->{port} = 3306 unless ( $self->{port} );
+
+    return $self;
+}
+
+1;


### PR DESCRIPTION
This pull request includes the addition of the `OracleProvider.pm` module.

Changes to `AbstractProvider.pm` include many formatting changes... look for significant changes under:
- The addition of the `_column_info()` subroutine
- The `query()`, `query_for_list()`, and `query_for_map()` methods now have several options. 
  - The user may specify a `column_info` array ref option to receive column information
  - The user may specify a `hash` truthy option to indicate that rows be generated as hashes (column name to value) rather than arrays.
  - The user may specify a `no_fetch` truthy option to indicate that fetching of row data should be skipped for a query (mostly for session modifying queries that throw errors when fetching row data)

Some cruft accidentally made it in at `AbstractProvider.pm:270` please withhold comments and just delete the line.