### PR TITLE
Added prepared statement template

### DIFF
--- a/README.mkdn
+++ b/README.mkdn
@@ -88,5 +88,5 @@ Please see those modules/websites for more information related to this module.
 - [Footprintless::Plugin::Database::DefaultCommandHelper](https://metacpan.org/pod/Footprintless::Plugin::Database::DefaultCommandHelper)
 - [Footprintless::Plugin::Database::MySqlProvider](https://metacpan.org/pod/Footprintless::Plugin::Database::MySqlProvider)
 - [Footprintless::Plugin::Database::OracleProvider](https://metacpan.org/pod/Footprintless::Plugin::Database::OracleProvider)
-- [Footprintless::Plugin::Database::PreparedStatementTemplate](https://metacpan.org/pod/Footprintless::Plugin::Database::PreparedStatementTemplate)
 - [Footprintless::Plugin::Database::PostgreSqlProvider](https://metacpan.org/pod/Footprintless::Plugin::Database::PostgreSqlProvider)
+- [Footprintless::Plugin::Database::PreparedStatementTemplate](https://metacpan.org/pod/Footprintless::Plugin::Database::PreparedStatementTemplate)

--- a/README.mkdn
+++ b/README.mkdn
@@ -87,4 +87,6 @@ Please see those modules/websites for more information related to this module.
 - [Footprintless::Plugin::Database::CsvProvider](https://metacpan.org/pod/Footprintless::Plugin::Database::CsvProvider)
 - [Footprintless::Plugin::Database::DefaultCommandHelper](https://metacpan.org/pod/Footprintless::Plugin::Database::DefaultCommandHelper)
 - [Footprintless::Plugin::Database::MySqlProvider](https://metacpan.org/pod/Footprintless::Plugin::Database::MySqlProvider)
+- [Footprintless::Plugin::Database::OracleProvider](https://metacpan.org/pod/Footprintless::Plugin::Database::OracleProvider)
+- [Footprintless::Plugin::Database::PreparedStatementTemplate](https://metacpan.org/pod/Footprintless::Plugin::Database::PreparedStatementTemplate)
 - [Footprintless::Plugin::Database::PostgreSqlProvider](https://metacpan.org/pod/Footprintless::Plugin::Database::PostgreSqlProvider)

--- a/lib/Footprintless/Plugin/Database/PreparedStatementTemplate.pm
+++ b/lib/Footprintless/Plugin/Database/PreparedStatementTemplate.pm
@@ -19,17 +19,11 @@ sub _transform_binding {
     my ( $template_key, $binding ) = @_;
     my $ref = ref($binding);
     my $new_binding = { template_key => $template_key };
-    if ( my $key =
-        ( ( !$ref && $binding ) || ( $ref eq 'HASH' && $binding->{key} ) ) )
-    {
+    if ( my $key = ( ( !$ref && $binding ) || ( $ref eq 'HASH' && $binding->{key} ) ) ) {
         $new_binding->{key} = $key;
     }
-    elsif (
-        my $reference = (
-                 ( $ref eq 'SCALAR' && $binding )
-              || ( $ref eq 'HASH' && $binding->{reference} )
-        )
-      )
+    elsif ( my $reference =
+        ( ( $ref eq 'SCALAR' && $binding ) || ( $ref eq 'HASH' && $binding->{reference} ) ) )
     {
         croak(
             "Template var [$template_key] - 'reference' property of binding is not a 'SCALAR' ref"
@@ -37,26 +31,19 @@ sub _transform_binding {
         $new_binding->{reference} = $reference;
     }
     elsif ( $ref eq 'HASH' && defined( $binding->{value} ) ) {
-        croak(
-            "'Template var [$template_key] - value' property of binding is a ref"
-        ) if ref( $binding->{value} );
+        croak("'Template var [$template_key] - value' property of binding is a ref")
+            if ref( $binding->{value} );
         $new_binding->{value} = $binding->{value};
     }
-    elsif (
-        my $code = (
-                 ( $ref eq 'CODE' && $binding )
-              || ( $ref eq 'HASH' && $binding->{code} )
-        )
-      )
+    elsif ( my $code =
+        ( ( $ref eq 'CODE' && $binding ) || ( $ref eq 'HASH' && $binding->{code} ) ) )
     {
-        croak(
-            "Template var [$template_key] - 'code' property of binding is not a 'CODE' ref"
-        ) unless ref($code) eq 'CODE';
+        croak("Template var [$template_key] - 'code' property of binding is not a 'CODE' ref")
+            unless ref($code) eq 'CODE';
         $new_binding->{code} = $code;
     }
     else {
-        croak( "Template var [$template_key] - binding [%s] is invalid",
-            Dumper($binding) );
+        croak( "Template var [$template_key] - binding [%s] is invalid", Dumper($binding) );
     }
     return $new_binding;
 }
@@ -65,29 +52,27 @@ sub _bind {
     my ( $binding, $context ) = @_;
     if ( defined( my $key = $binding->{key} ) ) {
         eval { $binding->{value} = $context->$key() }
-          if ( !defined( $binding->{value} = $context->{$key} ) );
+            if ( !defined( $binding->{value} = $context->{$key} ) );
         croak(
             "Cannot bind template var [$binding->{template_key}] - property [$key] cannot be bound in context"
         ) unless defined( $binding->{value} );
     }
     elsif ( defined( my $reference = $binding->{reference} ) ) {
-        croak(
-            "Cannot bind template var [$binding->{template_key}] - reference to undefined"
-        ) unless defined( $binding->{value} = $$reference );
+        croak("Cannot bind template var [$binding->{template_key}] - reference to undefined")
+            unless defined( $binding->{value} = $$reference );
     }
     elsif ( defined( my $code = $binding->{code} ) ) {
-        croak(
-            "Cannot bind template var [$binding->{template_key}] - code returns undefined"
-        ) unless defined( $binding->{value} = $code->() );
+        croak("Cannot bind template var [$binding->{template_key}] - code returns undefined")
+            unless defined( $binding->{value} = $code->() );
     }
 }
 
 sub _unbind {
     my ($binding) = @_;
     delete( $binding->{value} )
-      if defined( $binding->{key} )
-      || defined( $binding->{reference} )
-      || defined( $binding->{code} );
+        if defined( $binding->{key} )
+        || defined( $binding->{reference} )
+        || defined( $binding->{code} );
 }
 
 sub query {
@@ -96,7 +81,7 @@ sub query {
     if ( %{ $self->{bindings} } ) {
         foreach ( values( %{ $self->{bindings} } ) ) { _bind( $_, $context ) }
         $query->{parameters} =
-          [ map { $_->{value} } @{ $self->{parameter_bindings} } ];
+            [ map { $_->{value} } @{ $self->{parameter_bindings} } ];
         foreach ( values( %{ $self->{bindings} } ) ) { _unbind( $_, $context ) }
     }
     return $query;
@@ -109,6 +94,7 @@ sub _dice {
     }
     else {
         my $add_ix = 0;
+
         # We need at least one element with a blank string in split...
         foreach ( $text ? split( /\Q$key\E/, $text, -1 ) : ('') ) {
             push( @$index_to_key, $key ) if ( $add_ix++ );
@@ -120,16 +106,16 @@ sub _dice {
 sub _init {
     my ( $self, $sql_template, %bindings ) = @_;
     my @binding_keys =
-      sort { ( length($b) <=> length($a) ) || ( $a cmp $b ) }
-      keys(%bindings);
+        sort { ( length($b) <=> length($a) ) || ( $a cmp $b ) }
+        keys(%bindings);
     my @split_text;
     my @index_to_key;
     $self->{bindings} =
-      { map { $_ => _transform_binding( $_, $bindings{$_} ) } @binding_keys };
+        { map { $_ => _transform_binding( $_, $bindings{$_} ) } @binding_keys };
     _dice( $sql_template, \@split_text, \@index_to_key, @binding_keys );
     $self->{prepared_statement} = join( '?', @split_text );
     $self->{parameter_bindings} =
-      [ map { $self->{bindings}->{$_} } @index_to_key ];
+        [ map { $self->{bindings}->{$_} } @index_to_key ];
 
     my %used_keys = map { $_ => 1 } @index_to_key;
     foreach my $unused_key ( grep { !$used_keys{$_} } @binding_keys ) {
@@ -138,7 +124,6 @@ sub _init {
     }
     return $self;
 }
-
 1;
 __END__
 =head1 SYNOPSIS

--- a/lib/Footprintless/Plugin/Database/PreparedStatementTemplate.pm
+++ b/lib/Footprintless/Plugin/Database/PreparedStatementTemplate.pm
@@ -1,0 +1,234 @@
+use strict;
+use warnings;
+
+package Footprintless::Plugin::Database::PreparedStatementTemplate;
+
+use Carp;
+use Carp 'verbose';
+use Data::Dumper;
+use Log::Any;
+
+my $logger = Log::Any->get_logger();
+
+sub new {
+    my $self = bless( {}, shift );
+    $self->_init(@_);
+}
+
+sub _transform_binding {
+    my ( $template_key, $binding ) = @_;
+    my $ref = ref($binding);
+    my $new_binding = { template_key => $template_key };
+    if ( my $key =
+        ( ( !$ref && $binding ) || ( $ref eq 'HASH' && $binding->{key} ) ) )
+    {
+        $new_binding->{key} = $key;
+    }
+    elsif (
+        my $reference = (
+                 ( $ref eq 'SCALAR' && $binding )
+              || ( $ref eq 'HASH' && $binding->{reference} )
+        )
+      )
+    {
+        croak(
+            "Template var [$template_key] - 'reference' property of binding is not a 'SCALAR' ref"
+        ) unless ref($reference) eq 'SCALAR';
+        $new_binding->{reference} = $reference;
+    }
+    elsif ( $ref eq 'HASH' && defined( $binding->{value} ) ) {
+        croak(
+            "'Template var [$template_key] - value' property of binding is a ref"
+        ) if ref( $binding->{value} );
+        $new_binding->{value} = $binding->{value};
+    }
+    elsif (
+        my $code = (
+                 ( $ref eq 'CODE' && $binding )
+              || ( $ref eq 'HASH' && $binding->{code} )
+        )
+      )
+    {
+        croak(
+            "Template var [$template_key] - 'code' property of binding is not a 'CODE' ref"
+        ) unless ref($code) eq 'CODE';
+        $new_binding->{code} = $code;
+    }
+    else {
+        croak( "Template var [$template_key] - binding [%s] is invalid",
+            Dumper($binding) );
+    }
+    return $new_binding;
+}
+
+sub _bind {
+    my ( $binding, $context ) = @_;
+    if ( defined( my $key = $binding->{key} ) ) {
+        eval { $binding->{value} = $context->$key() }
+          if ( !defined( $binding->{value} = $context->{$key} ) );
+        croak(
+            "Cannot bind template var [$binding->{template_key}] - property [$key] cannot be bound in context"
+        ) unless defined( $binding->{value} );
+    }
+    elsif ( defined( my $reference = $binding->{reference} ) ) {
+        croak(
+            "Cannot bind template var [$binding->{template_key}] - reference to undefined"
+        ) unless defined( $binding->{value} = $$reference );
+    }
+    elsif ( defined( my $code = $binding->{code} ) ) {
+        croak(
+            "Cannot bind template var [$binding->{template_key}] - code returns undefined"
+        ) unless defined( $binding->{value} = $code->() );
+    }
+}
+
+sub _unbind {
+    my ($binding) = @_;
+    delete( $binding->{value} )
+      if defined( $binding->{key} )
+      || defined( $binding->{reference} )
+      || defined( $binding->{code} );
+}
+
+sub query {
+    my ( $self, $context ) = @_;
+    my $query = { sql => $self->{prepared_statement} };
+    if ( %{ $self->{bindings} } ) {
+        foreach ( values( %{ $self->{bindings} } ) ) { _bind( $_, $context ) }
+        $query->{parameters} =
+          [ map { $_->{value} } @{ $self->{parameter_bindings} } ];
+        foreach ( values( %{ $self->{bindings} } ) ) { _unbind( $_, $context ) }
+    }
+    return $query;
+}
+
+sub _dice {
+    my ( $text, $split_text, $index_to_key, $key, @keys ) = @_;
+    if ( !$key ) {
+        push( @$split_text, $text );
+    }
+    else {
+        my $add_ix = 0;
+        # We need at least one element with a blank string in split...
+        foreach ( $text ? split( /\Q$key\E/, $text, -1 ) : ('') ) {
+            push( @$index_to_key, $key ) if ( $add_ix++ );
+            _dice( $_, $split_text, $index_to_key, @keys );
+        }
+    }
+}
+
+sub _init {
+    my ( $self, $sql_template, %bindings ) = @_;
+    my @binding_keys =
+      sort { ( length($b) <=> length($a) ) || ( $a cmp $b ) }
+      keys(%bindings);
+    my @split_text;
+    my @index_to_key;
+    $self->{bindings} =
+      { map { $_ => _transform_binding( $_, $bindings{$_} ) } @binding_keys };
+    _dice( $sql_template, \@split_text, \@index_to_key, @binding_keys );
+    $self->{prepared_statement} = join( '?', @split_text );
+    $self->{parameter_bindings} =
+      [ map { $self->{bindings}->{$_} } @index_to_key ];
+
+    my %used_keys = map { $_ => 1 } @index_to_key;
+    foreach my $unused_key ( grep { !$used_keys{$_} } @binding_keys ) {
+        $logger->warn("Template var [$unused_key] is never used!");
+        delete( $self->{bindings}->{$unused_key} );
+    }
+    return $self;
+}
+
+1;
+__END__
+=head1 SYNOPSIS
+
+    use Footprintless::Plugin::Database::PreparedStatementTemplate;
+    
+    my $second_fruit;
+    my $statement = Footprintless::Plugin::Database::PreparedStatementTemplate->new(
+        "SELECT * FROM fruit_basket WHERE fruit IN ('_FRUIT_1_', '_FRUIT_2_', '_FRUIT_3_')",
+        _FRUIT_1_ => 'first_fruit',
+        _FRUIT_2_ => sub { $second_fruit },
+        _FRUIT_3_ => { value => 'banana' }
+    );
+    
+    my $context = { first_fruit => 'grape' };
+    $second_fruit = 'apple';
+    
+    my $query1 = $statement->query($context);
+    croak("query1 SQL bad")
+      unless $query1->{sql} eq
+      "SELECT * FROM fruit_basket WHERE fruit IN ('?', '?', '?')";
+    croak("query1, param[0] bad") unless $query1->{parameters}->[0] eq 'grape';
+    croak("query1, param[1] bad") unless $query1->{parameters}->[1] eq 'apple';
+    croak("query1, param[2] bad") unless $query1->{parameters}->[2] eq 'banana';
+    
+    $context->{first_fruit} = 'pear';
+    $second_fruit = 'strawberry';
+    
+    my $query2 = $statement->query($context);
+    croak("query2 SQL bad")
+      unless $query2->{sql} eq
+      "SELECT * FROM fruit_basket WHERE fruit IN ('?', '?', '?')";
+    croak("query2, param[0] bad") unless $query2->{parameters}->[0] eq 'pear';
+    croak("query2, param[1] bad") unless $query2->{parameters}->[1] eq 'strawberry';
+    croak("query2, param[2] bad") unless $query2->{parameters}->[2] eq 'banana';
+
+=head1 DESCRIPTION
+
+Footprintless::Plugin::Database::PreparedStatementTemplate
+
+Prepared statements are a best practice, yet they are a pain in the neck, since
+every parameter is represented by a '?' and the parameters are provided in an
+array of values that correspond to the '?' in the prepared statement. This
+class allows the user to create these painful prepared statements using named
+parameters AND binding them to a context either by properties, hard-coded values,
+and/or closures.
+
+Provides a base class implementing the common abstractions.  Other providers
+should extend this class and override methods as desired.  
+
+=constructor C<new($sql_template, %bindings)>
+
+Creates the prepared statement template with the given bindings. The key of each
+binding is the string to replace in the C<$sql_template> and the value of each binding
+tells this prepared statement template how to bind values to each of the parameters.
+The binding value may be one of the following:
+
+=over 4
+
+=item B<key>
+
+To bind a property from a context, the binding value should be a simple string with
+the property name, or a hash-ref like this: C<{ key => 'property_name' }> 
+
+=item B<code>
+
+To bind a property to a value returned from a closure, the binding value should be
+a CODE (subroutine) ref, or a hash-ref like this: C<{ code => sub {...} }>
+
+=item B<reference>
+
+To bind a property to a reference (variable), the binding value should be a
+scalar-ref, or a hash-ref like this: C<{ reference => \$variable }>
+
+=item B<value>
+
+To bind a property to a constant value, the binding value should be a hash-ref like
+this: C<{ value => 'constant_value' }>
+
+=back
+
+=method C<query($context)>
+
+Generate a query acceptable to the C<Footprintless::Plugin::Database::AbstractProvider>
+using this prepared statement template and a context to bind to. The context is either
+a class instance or hash-ref that has the properties identified in the bindings passed
+to the constructor. Properties are primarily a property of the hash-ref, but if it is
+not defined, the prepared statement template will attempt to call a no-arg method that
+has the name of the property to extract it's value.
+
+=head1 SEE ALSO
+
+C<Footprintless::Plugin::Database::AbstractProvider>

--- a/lib/Footprintless/Plugin/Database/PreparedStatementTemplate.pm
+++ b/lib/Footprintless/Plugin/Database/PreparedStatementTemplate.pm
@@ -186,9 +186,6 @@ class allows the user to create these painful prepared statements using named
 parameters AND binding them to a context either by properties, hard-coded values,
 and/or closures.
 
-Provides a base class implementing the common abstractions.  Other providers
-should extend this class and override methods as desired.  
-
 =constructor C<new($sql_template, %bindings)>
 
 Creates the prepared statement template with the given bindings. The key of each

--- a/t/Footprintless_Database_PreparedStatementTemplate.t
+++ b/t/Footprintless_Database_PreparedStatementTemplate.t
@@ -8,11 +8,11 @@ use File::Basename;
 use File::Spec;
 use Footprintless;
 use Footprintless::Util qw(
-  dumper
-  factory
-  slurp
-  spurt
-  temp_dir
+    dumper
+    factory
+    slurp
+    spurt
+    temp_dir
 );
 
 BEGIN {
@@ -40,8 +40,8 @@ BEGIN {
         my ( $self, $new_value ) = @_;
         my ($key) = $Context::AUTOLOAD =~ /^.*::(.*?)$/;
         my $value = defined($new_value)
-          ? $self->{_properties}->{$key} = $new_value
-          : $self->{_properties}->{$key};
+            ? $self->{_properties}->{$key} = $new_value
+            : $self->{_properties}->{$key};
         die("Undefined property [$key]") unless defined($value);
         return $value;
     }
@@ -70,20 +70,17 @@ my $logger = Log::Any->get_logger();
         music  => 'classical',
         sport  => 'soccer'
     );
-    my $statement =
-      Footprintless::Plugin::Database::PreparedStatementTemplate->new(
+    my $statement = Footprintless::Plugin::Database::PreparedStatementTemplate->new(
         'ONE *A* TWO *B* THREE *A* FOUR *B* FIVE *C* SIX *D* SEVEN',
         '*A*' => 'fruit',
         '*B*' => 'music',
         '*C*' => { key => 'color' },
         '*D*' => { key => 'sport' }
-      );
+    );
     is_deeply(
         $statement->query($context),
-        {
-            sql => 'ONE ? TWO ? THREE ? FOUR ? FIVE ? SIX ? SEVEN',
-            parameters =>
-              [ 'apple', 'classical', 'apple', 'classical', 'green', 'soccer' ]
+        {   sql        => 'ONE ? TWO ? THREE ? FOUR ? FIVE ? SIX ? SEVEN',
+            parameters => [ 'apple', 'classical', 'apple', 'classical', 'green', 'soccer' ]
         },
         'key 1'
     );
@@ -93,11 +90,8 @@ my $logger = Log::Any->get_logger();
     $context->{sport} = 'base jumping';
     is_deeply(
         $statement->query($context),
-        {
-            sql        => 'ONE ? TWO ? THREE ? FOUR ? FIVE ? SIX ? SEVEN',
-            parameters => [
-                'durian', 'ska', 'durian', 'ska', 'neon green', 'base jumping'
-            ]
+        {   sql        => 'ONE ? TWO ? THREE ? FOUR ? FIVE ? SIX ? SEVEN',
+            parameters => [ 'durian', 'ska', 'durian', 'ska', 'neon green', 'base jumping' ]
         },
         'key 2'
     );
@@ -105,18 +99,16 @@ my $logger = Log::Any->get_logger();
 
 # Test the template implementation of references
 {
-    my $value1 = "Hippo";
-    my $value2 = "Rhino";
-    my $statement =
-      Footprintless::Plugin::Database::PreparedStatementTemplate->new(
+    my $value1    = "Hippo";
+    my $value2    = "Rhino";
+    my $statement = Footprintless::Plugin::Database::PreparedStatementTemplate->new(
         'ONE *A* TWO *B* THREE *A* FOUR *B* FIVE',
         '*A*' => \$value1,
         '*B*' => { reference => \$value2 }
-      );
+    );
     is_deeply(
         $statement->query(),
-        {
-            sql        => 'ONE ? TWO ? THREE ? FOUR ? FIVE',
+        {   sql        => 'ONE ? TWO ? THREE ? FOUR ? FIVE',
             parameters => [ 'Hippo', 'Rhino', 'Hippo', 'Rhino' ]
         },
         'references 1'
@@ -125,8 +117,7 @@ my $logger = Log::Any->get_logger();
     $value2 = "Dog";
     is_deeply(
         $statement->query(),
-        {
-            sql        => 'ONE ? TWO ? THREE ? FOUR ? FIVE',
+        {   sql        => 'ONE ? TWO ? THREE ? FOUR ? FIVE',
             parameters => [ 'Cat', 'Dog', 'Cat', 'Dog' ]
         },
         'references 2'
@@ -137,38 +128,29 @@ my $logger = Log::Any->get_logger();
 {
     my $count = 1;
 
-    my $statement =
-      Footprintless::Plugin::Database::PreparedStatementTemplate->new(
+    my $statement = Footprintless::Plugin::Database::PreparedStatementTemplate->new(
         'ONE *A* TWO *B* THREE *A* FOUR *B* FIVE *C* SIX *D* SEVEN',
-        '*A*' => sub { "fruit $count" },
-        '*B*' => sub { "music $count" },
+        '*A*' => sub {"fruit $count"},
+        '*B*' => sub {"music $count"},
         '*C*' => {
-            code => sub { "color $count" }
+            code => sub {"color $count"}
         },
         '*D*' => {
-            code => sub { "sport $count" }
+            code => sub {"sport $count"}
         }
-      );
+    );
     is_deeply(
         $statement->query(),
-        {
-            sql        => 'ONE ? TWO ? THREE ? FOUR ? FIVE ? SIX ? SEVEN',
-            parameters => [
-                'fruit 1', 'music 1', 'fruit 1', 'music 1',
-                'color 1', 'sport 1'
-            ]
+        {   sql        => 'ONE ? TWO ? THREE ? FOUR ? FIVE ? SIX ? SEVEN',
+            parameters => [ 'fruit 1', 'music 1', 'fruit 1', 'music 1', 'color 1', 'sport 1' ]
         },
         'code 1'
     );
     $count = 2;
     is_deeply(
         $statement->query(),
-        {
-            sql        => 'ONE ? TWO ? THREE ? FOUR ? FIVE ? SIX ? SEVEN',
-            parameters => [
-                'fruit 2', 'music 2', 'fruit 2', 'music 2',
-                'color 2', 'sport 2'
-            ]
+        {   sql        => 'ONE ? TWO ? THREE ? FOUR ? FIVE ? SIX ? SEVEN',
+            parameters => [ 'fruit 2', 'music 2', 'fruit 2', 'music 2', 'color 2', 'sport 2' ]
         },
         'code 2'
     );
@@ -179,16 +161,14 @@ my $logger = Log::Any->get_logger();
     my $fruit = "fruit 1";
     my $music = "music 1";
 
-    my $statement =
-      Footprintless::Plugin::Database::PreparedStatementTemplate->new(
+    my $statement = Footprintless::Plugin::Database::PreparedStatementTemplate->new(
         'ONE *A* TWO *B* THREE *A* FOUR *B* FIVE',
         '*A*' => { value => $fruit },
         '*B*' => { value => $music }
-      );
+    );
     is_deeply(
         $statement->query(),
-        {
-            sql        => 'ONE ? TWO ? THREE ? FOUR ? FIVE',
+        {   sql        => 'ONE ? TWO ? THREE ? FOUR ? FIVE',
             parameters => [ 'fruit 1', 'music 1', 'fruit 1', 'music 1' ]
         },
         'value 1'
@@ -197,8 +177,7 @@ my $logger = Log::Any->get_logger();
     $music = "music 2";
     is_deeply(
         $statement->query(),
-        {
-            sql => 'ONE ? TWO ? THREE ? FOUR ? FIVE',
+        {   sql => 'ONE ? TWO ? THREE ? FOUR ? FIVE',
 
             # no change
             parameters => [ 'fruit 1', 'music 1', 'fruit 1', 'music 1' ]
@@ -215,24 +194,19 @@ my $logger = Log::Any->get_logger();
         music  => 'classical',
     );
 
-    my $statement =
-      Footprintless::Plugin::Database::PreparedStatementTemplate->new(
+    my $statement = Footprintless::Plugin::Database::PreparedStatementTemplate->new(
         'XXXXX ONE X TWO XX THREE X FOUR XX FIVE XXX SICKS XXXX SEVEN XXXXX',
-        X     => sub     { "fruit $count" },
+        X     => sub     {"fruit $count"},
         XX    => \$count,
         XXX   => 'music',
         XXXX  => 'color',
         XXXXX => { value => 'pig' }
-      );
+    );
 
     is_deeply(
         $statement->query($context),
-        {
-            sql        => '? ONE ? TWO ? THREE ? FOUR ? FIVE ? SICKS ? SEVEN ?',
-            parameters => [
-                'pig', 'fruit 1',   '1',     'fruit 1',
-                '1',   'classical', 'green', 'pig'
-            ]
+        {   sql        => '? ONE ? TWO ? THREE ? FOUR ? FIVE ? SICKS ? SEVEN ?',
+            parameters => [ 'pig', 'fruit 1', '1', 'fruit 1', '1', 'classical', 'green', 'pig' ]
         },
         'dangerous naming 1'
     );
@@ -241,26 +215,20 @@ my $logger = Log::Any->get_logger();
     $context->color('neon green');
     is_deeply(
         $statement->query($context),
-        {
-            sql        => '? ONE ? TWO ? THREE ? FOUR ? FIVE ? SICKS ? SEVEN ?',
-            parameters => [
-                'pig', 'fruit 2', '2',          'fruit 2',
-                '2',   'ska',     'neon green', 'pig'
-            ]
+        {   sql        => '? ONE ? TWO ? THREE ? FOUR ? FIVE ? SICKS ? SEVEN ?',
+            parameters => [ 'pig', 'fruit 2', '2', 'fruit 2', '2', 'ska', 'neon green', 'pig' ]
         },
         'dangerous naming 2'
     );
 
-    $statement =
-      Footprintless::Plugin::Database::PreparedStatementTemplate->new(
+    $statement = Footprintless::Plugin::Database::PreparedStatementTemplate->new(
         'XXX ONE XXX TWO XXX',
-        X     => { value => 'AAA' },
-        XX    => { value => 'BBB' }
-      );
+        X  => { value => 'AAA' },
+        XX => { value => 'BBB' }
+    );
     is_deeply(
         $statement->query($context),
-        {
-            sql        => '?? ONE ?? TWO ??',
+        {   sql        => '?? ONE ?? TWO ??',
             parameters => [ 'BBB', 'AAA', 'BBB', 'AAA', 'BBB', 'AAA' ]
         },
         'dangerous naming 3'

--- a/t/Footprintless_Database_PreparedStatementTemplate.t
+++ b/t/Footprintless_Database_PreparedStatementTemplate.t
@@ -1,0 +1,269 @@
+use strict;
+use warnings;
+
+use Data::Dumper;
+use lib 't/lib';
+use Test::More tests => 12;
+use File::Basename;
+use File::Spec;
+use Footprintless;
+use Footprintless::Util qw(
+  dumper
+  factory
+  slurp
+  spurt
+  temp_dir
+);
+
+BEGIN {
+
+    package Context;
+
+    sub new {
+        my $self = bless( {}, shift );
+        $self->_init(@_);
+    }
+
+    sub _init {
+        my ( $self, %props ) = @_;
+        foreach my $key ( grep { substr( $_, 0, 1 ) ne '_' } keys(%props) ) {
+            $self->{$key} = $props{$key};
+        }
+        $self->{_properties} = {
+            map { substr( $_, 1 ) => $props{$_} }
+            grep { substr( $_, 0, 1 ) eq '_' } keys(%props)
+        };
+        return $self;
+    }
+
+    sub AUTOLOAD {
+        my ( $self, $new_value ) = @_;
+        my ($key) = $Context::AUTOLOAD =~ /^.*::(.*?)$/;
+        my $value = defined($new_value)
+          ? $self->{_properties}->{$key} = $new_value
+          : $self->{_properties}->{$key};
+        die("Undefined property [$key]") unless defined($value);
+        return $value;
+    }
+}
+
+BEGIN { use_ok('Footprintless::Plugin::Database::PreparedStatementTemplate') }
+
+eval {
+    require Getopt::Long;
+    Getopt::Long::Configure( 'pass_through', 'bundling' );
+    my $level = 'error';
+    Getopt::Long::GetOptions( 'log:s' => \$level );
+
+    require Log::Any::Adapter;
+    Log::Any::Adapter->set( 'Stdout',
+        log_level => Log::Any::Adapter::Util::numeric_level($level) );
+};
+
+my $logger = Log::Any->get_logger();
+
+# Test the template implementation of key
+{
+    my $context = Context->new(
+        _fruit => 'apple',
+        _color => 'green',
+        music  => 'classical',
+        sport  => 'soccer'
+    );
+    my $statement =
+      Footprintless::Plugin::Database::PreparedStatementTemplate->new(
+        'ONE *A* TWO *B* THREE *A* FOUR *B* FIVE *C* SIX *D* SEVEN',
+        '*A*' => 'fruit',
+        '*B*' => 'music',
+        '*C*' => { key => 'color' },
+        '*D*' => { key => 'sport' }
+      );
+    is_deeply(
+        $statement->query($context),
+        {
+            sql => 'ONE ? TWO ? THREE ? FOUR ? FIVE ? SIX ? SEVEN',
+            parameters =>
+              [ 'apple', 'classical', 'apple', 'classical', 'green', 'soccer' ]
+        },
+        'key 1'
+    );
+    $context->fruit('durian');
+    $context->color('neon green');
+    $context->{music} = 'ska';
+    $context->{sport} = 'base jumping';
+    is_deeply(
+        $statement->query($context),
+        {
+            sql        => 'ONE ? TWO ? THREE ? FOUR ? FIVE ? SIX ? SEVEN',
+            parameters => [
+                'durian', 'ska', 'durian', 'ska', 'neon green', 'base jumping'
+            ]
+        },
+        'key 2'
+    );
+}
+
+# Test the template implementation of references
+{
+    my $value1 = "Hippo";
+    my $value2 = "Rhino";
+    my $statement =
+      Footprintless::Plugin::Database::PreparedStatementTemplate->new(
+        'ONE *A* TWO *B* THREE *A* FOUR *B* FIVE',
+        '*A*' => \$value1,
+        '*B*' => { reference => \$value2 }
+      );
+    is_deeply(
+        $statement->query(),
+        {
+            sql        => 'ONE ? TWO ? THREE ? FOUR ? FIVE',
+            parameters => [ 'Hippo', 'Rhino', 'Hippo', 'Rhino' ]
+        },
+        'references 1'
+    );
+    $value1 = "Cat";
+    $value2 = "Dog";
+    is_deeply(
+        $statement->query(),
+        {
+            sql        => 'ONE ? TWO ? THREE ? FOUR ? FIVE',
+            parameters => [ 'Cat', 'Dog', 'Cat', 'Dog' ]
+        },
+        'references 2'
+    );
+}
+
+# Test the template implementation of code
+{
+    my $count = 1;
+
+    my $statement =
+      Footprintless::Plugin::Database::PreparedStatementTemplate->new(
+        'ONE *A* TWO *B* THREE *A* FOUR *B* FIVE *C* SIX *D* SEVEN',
+        '*A*' => sub { "fruit $count" },
+        '*B*' => sub { "music $count" },
+        '*C*' => {
+            code => sub { "color $count" }
+        },
+        '*D*' => {
+            code => sub { "sport $count" }
+        }
+      );
+    is_deeply(
+        $statement->query(),
+        {
+            sql        => 'ONE ? TWO ? THREE ? FOUR ? FIVE ? SIX ? SEVEN',
+            parameters => [
+                'fruit 1', 'music 1', 'fruit 1', 'music 1',
+                'color 1', 'sport 1'
+            ]
+        },
+        'code 1'
+    );
+    $count = 2;
+    is_deeply(
+        $statement->query(),
+        {
+            sql        => 'ONE ? TWO ? THREE ? FOUR ? FIVE ? SIX ? SEVEN',
+            parameters => [
+                'fruit 2', 'music 2', 'fruit 2', 'music 2',
+                'color 2', 'sport 2'
+            ]
+        },
+        'code 2'
+    );
+}
+
+# Test the template implementation of value
+{
+    my $fruit = "fruit 1";
+    my $music = "music 1";
+
+    my $statement =
+      Footprintless::Plugin::Database::PreparedStatementTemplate->new(
+        'ONE *A* TWO *B* THREE *A* FOUR *B* FIVE',
+        '*A*' => { value => $fruit },
+        '*B*' => { value => $music }
+      );
+    is_deeply(
+        $statement->query(),
+        {
+            sql        => 'ONE ? TWO ? THREE ? FOUR ? FIVE',
+            parameters => [ 'fruit 1', 'music 1', 'fruit 1', 'music 1' ]
+        },
+        'value 1'
+    );
+    $fruit = "fruit 2";
+    $music = "music 2";
+    is_deeply(
+        $statement->query(),
+        {
+            sql => 'ONE ? TWO ? THREE ? FOUR ? FIVE',
+
+            # no change
+            parameters => [ 'fruit 1', 'music 1', 'fruit 1', 'music 1' ]
+        },
+        'value 2'
+    );
+}
+
+# Test dangerous naming
+{
+    my $count   = 1;
+    my $context = Context->new(
+        _color => 'green',
+        music  => 'classical',
+    );
+
+    my $statement =
+      Footprintless::Plugin::Database::PreparedStatementTemplate->new(
+        'XXXXX ONE X TWO XX THREE X FOUR XX FIVE XXX SICKS XXXX SEVEN XXXXX',
+        X     => sub     { "fruit $count" },
+        XX    => \$count,
+        XXX   => 'music',
+        XXXX  => 'color',
+        XXXXX => { value => 'pig' }
+      );
+
+    is_deeply(
+        $statement->query($context),
+        {
+            sql        => '? ONE ? TWO ? THREE ? FOUR ? FIVE ? SICKS ? SEVEN ?',
+            parameters => [
+                'pig', 'fruit 1',   '1',     'fruit 1',
+                '1',   'classical', 'green', 'pig'
+            ]
+        },
+        'dangerous naming 1'
+    );
+    $count = 2;
+    $context->{music} = 'ska';
+    $context->color('neon green');
+    is_deeply(
+        $statement->query($context),
+        {
+            sql        => '? ONE ? TWO ? THREE ? FOUR ? FIVE ? SICKS ? SEVEN ?',
+            parameters => [
+                'pig', 'fruit 2', '2',          'fruit 2',
+                '2',   'ska',     'neon green', 'pig'
+            ]
+        },
+        'dangerous naming 2'
+    );
+
+    $statement =
+      Footprintless::Plugin::Database::PreparedStatementTemplate->new(
+        'XXX ONE XXX TWO XXX',
+        X     => { value => 'AAA' },
+        XX    => { value => 'BBB' }
+      );
+    is_deeply(
+        $statement->query($context),
+        {
+            sql        => '?? ONE ?? TWO ??',
+            parameters => [ 'BBB', 'AAA', 'BBB', 'AAA', 'BBB', 'AAA' ]
+        },
+        'dangerous naming 3'
+    );
+
+}


### PR DESCRIPTION
`Footprintless::Plugin::Database::PreparedStatementTemplate`

Prepared statements are a best practice, yet they are a pain in the neck, since every parameter is represented by a '?' and the parameters are provided in an array of values that correspond to the '?' in the prepared statement. This class allows the user to create these painful prepared statements using named parameters AND binding them to a context either by properties, hard-coded values, and/or closures.

See POD documentation and `t/Footprintless_Database_PreparedStatementTemplate.t` for API details...
