### PR TITLE
Update template to skip over SQL comments

### DIFF
--- a/lib/Footprintless/Plugin/Database/PreparedStatementTemplate.pm
+++ b/lib/Footprintless/Plugin/Database/PreparedStatementTemplate.pm
@@ -15,6 +15,75 @@ sub new {
     $self->_init(@_);
 }
 
+sub _init {
+    my ( $self, $sql_template, %bindings ) = @_;
+    my @binding_keys =
+        sort { ( length($b) <=> length($a) ) || ( $a cmp $b ) }
+        keys(%bindings);
+    my @split_text;
+    my @index_to_key;
+    $self->{bindings} =
+        { map { $_ => _transform_binding( $_, $bindings{$_} ) } @binding_keys };
+    _dice( _remove_comments($sql_template), \@split_text, \@index_to_key, @binding_keys );
+    $self->{prepared_statement} = join( '?', @split_text );
+    $self->{parameter_bindings} =
+        [ map { $self->{bindings}->{$_} } @index_to_key ];
+
+    my %used_keys = map { $_ => 1 } @index_to_key;
+    foreach my $unused_key ( grep { !$used_keys{$_} } @binding_keys ) {
+        $logger->warn("Template var [$unused_key] is never used!");
+        delete( $self->{bindings}->{$unused_key} );
+    }
+    return $self;
+}
+
+sub _bind {
+    my ( $binding, $context ) = @_;
+    if ( defined( my $key = $binding->{key} ) ) {
+        eval { $binding->{value} = $context->$key() }
+            if ( !defined( $binding->{value} = $context->{$key} ) );
+        croak(
+            "Cannot bind template var [$binding->{template_key}] - property [$key] cannot be bound in context"
+        ) unless defined( $binding->{value} );
+    }
+    elsif ( defined( my $reference = $binding->{reference} ) ) {
+        croak("Cannot bind template var [$binding->{template_key}] - reference to undefined")
+            unless defined( $binding->{value} = $$reference );
+    }
+    elsif ( defined( my $code = $binding->{code} ) ) {
+        croak("Cannot bind template var [$binding->{template_key}] - code returns undefined")
+            unless defined( $binding->{value} = $code->() );
+    }
+}
+
+sub _dice {
+    my ( $text, $split_text, $index_to_key, $key, @keys ) = @_;
+    if ( !$key ) {
+        push( @$split_text, $text );
+    }
+    else {
+        my $add_ix = 0;
+
+        # We need at least one element with a blank string in split...
+        foreach ( $text ? split( /\Q$key\E/, $text, -1 ) : ('') ) {
+            push( @$index_to_key, $key ) if ( $add_ix++ );
+            _dice( $_, $split_text, $index_to_key, @keys );
+        }
+    }
+}
+
+sub query {
+    my ( $self, $context ) = @_;
+    my $query = { sql => $self->{prepared_statement} };
+    if ( %{ $self->{bindings} } ) {
+        foreach ( values( %{ $self->{bindings} } ) ) { _bind( $_, $context ) }
+        $query->{parameters} =
+            [ map { $_->{value} } @{ $self->{parameter_bindings} } ];
+        foreach ( values( %{ $self->{bindings} } ) ) { _unbind( $_, $context ) }
+    }
+    return $query;
+}
+
 sub _remove_comments {
     my ($sql) = @_;
     my $sql_out;
@@ -86,25 +155,6 @@ sub _transform_binding {
     return $new_binding;
 }
 
-sub _bind {
-    my ( $binding, $context ) = @_;
-    if ( defined( my $key = $binding->{key} ) ) {
-        eval { $binding->{value} = $context->$key() }
-            if ( !defined( $binding->{value} = $context->{$key} ) );
-        croak(
-            "Cannot bind template var [$binding->{template_key}] - property [$key] cannot be bound in context"
-        ) unless defined( $binding->{value} );
-    }
-    elsif ( defined( my $reference = $binding->{reference} ) ) {
-        croak("Cannot bind template var [$binding->{template_key}] - reference to undefined")
-            unless defined( $binding->{value} = $$reference );
-    }
-    elsif ( defined( my $code = $binding->{code} ) ) {
-        croak("Cannot bind template var [$binding->{template_key}] - code returns undefined")
-            unless defined( $binding->{value} = $code->() );
-    }
-}
-
 sub _unbind {
     my ($binding) = @_;
     delete( $binding->{value} )
@@ -113,57 +163,9 @@ sub _unbind {
         || defined( $binding->{code} );
 }
 
-sub query {
-    my ( $self, $context ) = @_;
-    my $query = { sql => $self->{prepared_statement} };
-    if ( %{ $self->{bindings} } ) {
-        foreach ( values( %{ $self->{bindings} } ) ) { _bind( $_, $context ) }
-        $query->{parameters} =
-            [ map { $_->{value} } @{ $self->{parameter_bindings} } ];
-        foreach ( values( %{ $self->{bindings} } ) ) { _unbind( $_, $context ) }
-    }
-    return $query;
-}
-
-sub _dice {
-    my ( $text, $split_text, $index_to_key, $key, @keys ) = @_;
-    if ( !$key ) {
-        push( @$split_text, $text );
-    }
-    else {
-        my $add_ix = 0;
-
-        # We need at least one element with a blank string in split...
-        foreach ( $text ? split( /\Q$key\E/, $text, -1 ) : ('') ) {
-            push( @$index_to_key, $key ) if ( $add_ix++ );
-            _dice( $_, $split_text, $index_to_key, @keys );
-        }
-    }
-}
-
-sub _init {
-    my ( $self, $sql_template, %bindings ) = @_;
-    my @binding_keys =
-        sort { ( length($b) <=> length($a) ) || ( $a cmp $b ) }
-        keys(%bindings);
-    my @split_text;
-    my @index_to_key;
-    $self->{bindings} =
-        { map { $_ => _transform_binding( $_, $bindings{$_} ) } @binding_keys };
-    _dice( _remove_comments($sql_template), \@split_text, \@index_to_key, @binding_keys );
-    $self->{prepared_statement} = join( '?', @split_text );
-    $self->{parameter_bindings} =
-        [ map { $self->{bindings}->{$_} } @index_to_key ];
-
-    my %used_keys = map { $_ => 1 } @index_to_key;
-    foreach my $unused_key ( grep { !$used_keys{$_} } @binding_keys ) {
-        $logger->warn("Template var [$unused_key] is never used!");
-        delete( $self->{bindings}->{$unused_key} );
-    }
-    return $self;
-}
 1;
 __END__
+
 =head1 SYNOPSIS
 
     use Footprintless::Plugin::Database::PreparedStatementTemplate;


### PR DESCRIPTION
So some templates will contain SQL block comments (/* */)  and line comments (--).
Sometimes the bound tokens show up in these comments and can create a really nasty case where these commented tokens are changed to ? by the prepared statement template and then a parameter is
added to the parameter list to correspond with it - I think this is enough to describe the problem.

This commit removes all comments from the SQL template before we go and make it a prepared statement - thus eliminating this problem.

There will be a subsequent commit on this pull request that will simply be reordering the methods in the `Footprintless::Database::PreparedStatementTemplate`